### PR TITLE
[figma]:update to 5.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notta-web-icon",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Icons for Notta Web",
   "main": "dist/index.js",
   "module": "src/icons.js",


### PR DESCRIPTION
5.7.0 遗漏了这两个图标的名字更改：sideBar-folderOpen 改为sideBar-folder-open；sideBar-shared-folderOpen 改为sideBar-sharedFolder-open