### PR TITLE
chore(deps): 将仅用于示例的运行时依赖移至 devDependencies（消除消费方重复 React）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notta-web-icon",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Icons for Notta Web",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -43,12 +43,7 @@
     "style": "fill"
   },
   "license": "MIT",
-  "dependencies": {
-    "message-like-antd": "^0.0.1",
-    "normalize.css": "^8.0.1",
-    "react-copy-to-clipboard": "^5.0.3",
-    "styled-components": "^5.1.1"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
@@ -69,9 +64,12 @@
     "figma-js": "^1.11.0",
     "fs-extra": "^9.0.1",
     "got": "^11.5.1",
+    "message-like-antd": "^0.0.1",
+    "normalize.css": "^8.0.1",
     "p-queue": "2.4.2",
     "prettier-eslint": "^9.0.0",
     "react": "^16.13.1",
+    "react-copy-to-clipboard": "^5.0.3",
     "react-dom": "^16.13.1",
     "rollup": "^1.19.4",
     "rollup-plugin-babel": "^4.3.3",
@@ -79,6 +77,7 @@
     "rollup-plugin-postcss": "^3.1.3",
     "rollup-plugin-serve": "^1.0.3",
     "rollup-plugin-uglify": "^6.0.4",
+    "styled-components": "^5.1.1",
     "svgo": "^1.3.0",
     "uppercamelcase": "^3.0.0"
   }


### PR DESCRIPTION
## 背景

#232 已将图标组件从函数组件 `defaultProps` 改为 JS 默认参数，并把 `react`/`react-dom` 放入 `peerDependencies`（`>=16.8.0`），修复了 **React 19 下函数组件 `defaultProps` 失效**、导致 `size`/`color` 默认值丢失（图标变大、变黑）的问题。

但 `dependencies` 中仍保留了 4 个**仅供图标展示页使用**的运行时依赖：

| 依赖 | 仅被引用于 |
|---|---|
| `styled-components` | `src/App.js`、`src/components/Header.js`、`src/components/IconWrapper.js` |
| `react-copy-to-clipboard` | `src/components/IconWrapper.js` |
| `message-like-antd` | `src/components/IconWrapper.js` |
| `normalize.css` | `src/main.js` |

发布产物 `dist` 仅由 `src/icons` 打包（见 `build/rollup.config.bundle.js` 的 input），**完全不引用**以上依赖。

## 改动

- 将上述 4 个依赖从 `dependencies` 移至 `devDependencies`（本地开发 / 展示页不受影响）
- `dependencies` 变为空 —— 发布包不再携带任何运行时依赖，仅声明 React peer
- 版本号 `9.0.1` → `9.0.2`

## 对不同 React 版本消费方的影响

- **React 19**：✅ 图标正常渲染（默认参数，#232 已修复）；并且**不再被动引入第二个 React 副本**。
- **React 16.8 / 17 / 18**：✅ 无回归 —— 默认参数是纯 JS，peer 维持 `>=16.8.0`，单一构建兼容全部版本，无需多构建/分版本维护。
- **所有版本（核心收益）**：`react-copy-to-clipboard@5` 会传递引入 `react@16`，使消费方出现**重复 React**（duplicate React → invalid hook call 风险 + 打包体积增大）。移除后，notta-web-icon 不再向消费方依赖树注入额外的 React 副本，依赖树更干净、安装体积更小。

> 实测：notta_brain_web 升级 React 19 时，lockfile 中的 `react@16` 孤岛正是由 `react-copy-to-clipboard@5`（经 notta-web-icon、react-share 传递）引入。

## 风险

极低。`dist` 产物不变（图标代码从不引用这些依赖），仅调整发布包的依赖声明；展示页所需依赖已保留在 `devDependencies`，`pnpm dev` 不受影响。

## 后续

合并并发布 `9.0.2` 后，消费方（notta_brain_web web_1 / web_4 等）将 `notta-web-icon` 升级到 `^9.0.2`，即可同时获得：React 19 兼容（#232）+ 干净依赖树（本 PR）。
