### PR TITLE
ci: 发布后回写 Figma 图标源码至 master，修复 src/ 长期漂移

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,8 +12,13 @@ jobs:
   icon_automation:
     name: figma icon automation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v2
+      with:
+        # PAT with write access so the commit-back step can push to master
+        token: ${{ secrets.GH_TOKEN }}
     - uses: actions/setup-node@v2
       with:
         node-version: '20.x'
@@ -34,6 +39,20 @@ jobs:
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    # 把 Figma 重新生成的图标源码回写到仓库，消除 src/ 与已发布 dist/ 的漂移。
+    # 仅提交 src/（dist/ 已在 .gitignore），不触碰 package.json，配合 paths 过滤与
+    # [skip ci] 双重保证不会自我触发新一轮工作流。
+    - name: Commit regenerated icon sources back to master
+      run: |
+        git config user.name "notta-icon-bot"
+        git config user.email "icon-bot@notta.ai"
+        git add src
+        if git diff --cached --quiet; then
+          echo "图标源码无变化，跳过回写。"
+        else
+          git commit -m "chore(icons): 同步 Figma 重新生成的图标源码 [skip ci]"
+          git push origin HEAD:master
+        fi
     - name: Pull Request URL
       uses: kceb/pull-request-url-action@v2
       id: pr-url


### PR DESCRIPTION
## 背景：`src/` 不是手工源码，而是一份 2022-10-20 的 Figma 抓取快照

`src/data.json`、`src/svg/`、`src/icons/` 都**不是手工维护的源码**，而是同一次 Figma 抓取的三个侧面：

1. **抓取**（`bin/fetchSVG.js`，CI 里等价的 `primer/figma-action`）：遍历 Figma 文档，把**每一个 `type === "COMPONENT"` 的节点**写进 `src/data.json`，并把对应 SVG 下载到 `src/svg/<name>.svg`。
   - 关键点：`data.json` **不是白名单**，而是“当前 Figma 有多少个 COMPONENT”的快照 —— 条目数 == 抓取那一刻 Figma 的组件数。（`data.json` 里的 `id:"242:4"`、`key`、`image:"https://figma-alpha-api…"` 全是 Figma API 产物，不可能手写。）
2. **生成**（`yarn generate` = `rm -rf src/icons && node bin/build.js`）：读 `data.json`，逐个把 `svg/<name>.svg` 编译成 `icons/<name>.js`，并清空重写 `icons.js` / `icons.d.ts`。所以 `icons/` 永远**精确等于** `data.json`。
3. **打包发布**（`build`/`build:bundle` → `dist` → `npm publish`）：`files: ["dist"]`，消费方只拿到 `dist`。

## 问题：提交进仓库的这份快照冻结在 2022-10-20，从未回写

| 工件 | 仓库里 | 含义 |
|---|---|---|
| `src/data.json` | **161** | 2022-10-20 那次抓取时 Figma 的组件数 |
| `src/icons/`、`icons.js`、`icons.d.ts` | **161** | 由同一份 `data.json` 编译，精确相等 |
| `src/svg/` | **214** | 161 个在用 + **53 个孤儿**（见下）|
| 已发布 `dist`（消费方实际安装）| **355** | 每次发布由 CI 现抓 Figma 重新生成 |

- **为什么 `data.json` 是 161、发布却是 355**：CI 每次发布会用 `primer/figma-action` **重新抓取当前 Figma（约 355 个 COMPONENT）**，覆盖 `src/data.json` + `src/svg/`，再 `yarn generate` 把 `icons/`/`icons.js`/`icons.d.ts` 全量重建到约 355，然后打包发布。**仓库里那份 161 自始至终不参与发布。** 161 是 2022 年 Figma 的组件数，355 是现在的 —— 四年里 Figma 多了约 194 个组件，而仓库快照一直没回写。
- **为什么 `svg/` 是 214 而不是 161**：`yarn generate` 只 `rm -rf src/icons`，**从不清理 `src/svg/`**，历史 SVG 会一直堆积。这 53 个孤儿没被 `data.json` 引用、不会编译成组件，绝大多数是当年从 feather-icons 风格脚手架带来、没删干净的 starter（`arrow-*`、`chevron-*`、`bell`、`cloud-*`、`battery`、`camera`、`clock`、`code`…），外加 3 个没进 `data.json` 的 `public-back-left/right`、`public-share`。

## 实测影响：消费方没坏，但仓库源码具误导性

- 已发布 **8.0.6 与 9.0.1 导出完全一致**（都 355 个，名字逐一相同，`diff` 干净，0 增 0 删）—— 9.0 **没有移除**任何图标。
- `notta_brain_web` 实际从 `notta-web-icon` 导入 **167** 个图标，**在 9.0.1 里 0 缺失**，升级不会坏。
- 但这 167 个里有 **83 个在仓库 `src/` 里根本搜不到**（只存在于发布的 `dist`），例如：

  ```
  FilesPdfOutlined          ← library/.../FileTypeIcon
  FilesMarkdownFill         ← smart-bar/.../business
  FilesXlsxOutlinedFilled   ← smart-bar/.../artifact-card
  AccountPreferenceSettings ← layout/SettingLayout/...
  LoginSso                  ← components/modals/SsoPermissionDialog
  MailInterview             ← prompt-tools/.../ToolIcon
  ```

  它们能工作，纯粹因为消费方拿的是 CI 现场生成的 `dist`，不是这份过期 `src`。

> 所谓“`src/icons.d.ts` 少了一百多个图标”，缺的不是发布包，而是仓库这份四年前的快照。

## 改动

在 `npm publish` 成功后新增一步，把 CI 重新生成的 `src/` 回写 `master`：

```yaml
- name: Commit regenerated icon sources back to master
  run: |
    git config user.name "notta-icon-bot"
    git config user.email "icon-bot@notta.ai"
    git add src
    if git diff --cached --quiet; then
      echo "图标源码无变化，跳过回写。"
    else
      git commit -m "chore(icons): 同步 Figma 重新生成的图标源码 [skip ci]"
      git push origin HEAD:master
    fi
```

配套：`checkout` 改用 `secrets.GH_TOKEN`（具写权限）以回写 `master`；job 增加 `permissions: contents: write`。

## 为什么不会自我触发死循环

- 触发条件是 `push` 到 `master` 且 `paths: [package.json]`；本步骤**只提交 `src/`**，不碰 `package.json` → 路径不命中。
- 提交信息带 `[skip ci]` → 双保险。
- 只提交 `src/`，`dist/` 已 gitignore，不入库。

## 对消费方的影响

**运行时零影响。** 发布产物 `dist` 完全不变（始终是 CI 现抓 Figma 生成）；本 PR 只让**仓库源码**重新反映真实图标集。收益：仓库可浏览、`data.json`/`icons.d.ts` 准确、git 历史能看出每次 Figma 增删了哪些图标。

> 可选后续（本 PR 不含，避免扩大范围）：在抓取前清空 `src/svg/`，或按 `data.json` 对 `svg/` 剪枝，可一并清掉那 53 个 feather 遗留 SVG。

## 生效方式与合并顺序

首次回写发生在**下一次成功发布**时 —— 届时一次性把 `src/` 从 161 补齐到当前 Figma 全量（约 355），自动消除历史漂移。

建议**先合本 PR，再合 #236**（`9.0.1 → 9.0.2`）：这样 #236 触发的发布会跑新版 workflow，发 `9.0.2` 的同时完成首次回写。若 #236 已先合，则等下一次版本 bump 自动补齐。
